### PR TITLE
Add to_hash to convert string values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - Unreleased
+
+### Changed
+
+- `to_hash` to turn StructuredString values into String
+
 ## [0.1.2] - Unreleased
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contours (0.1.2)
+    contours (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/contours/blended_hash.rb
+++ b/lib/contours/blended_hash.rb
@@ -27,8 +27,6 @@ module Contours
   #
   # See the source of this #{name} class for more details.
   class BlendedHash < DelegateClass(Hash)
-    alias_method :to_hash, :__getobj__
-
     # Ensure that the initial hash is a BlendedHash
     def self.init(initial_hash)
       if initial_hash.is_a?(BlendedHash)
@@ -160,6 +158,25 @@ module Contours
         [original, extra].flatten.compact.uniq
       else
         extra
+      end
+    end
+
+    def to_hash
+      deep_stringify_structured_strings(__getobj__)
+    end
+
+    private
+
+    def deep_stringify_structured_strings(obj)
+      case obj
+      when Hash
+        obj.transform_values { |v| deep_stringify_structured_strings(v) }
+      when Array
+        obj.map { |v| deep_stringify_structured_strings(v) }
+      when StructuredString
+        obj.to_s
+      else
+        obj
       end
     end
   end

--- a/lib/contours/version.rb
+++ b/lib/contours/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Contours
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/test/test_blended_hash.rb
+++ b/test/test_blended_hash.rb
@@ -113,6 +113,20 @@ module Contours
         blended = TestBlend.new({simple: "text", complex: {object: StructuredString.init("text").first("begin")}})
         expect(**blended).must_equal({simple: "text", complex: {object: "begin text"}})
       end
+
+      it "recursively converts StructuredString values to String when using **" do
+        structured = StructuredString.init("text").first("begin")
+        blended = TestBlend.new({
+          simple: "text",
+          complex: {object: structured}
+        })
+
+        result = {**blended}
+        expect(result[:simple]).must_equal("text")
+        expect(result[:complex][:object]).must_equal("begin text")
+        expect(result[:complex][:object]).must_be_kind_of(String)
+        expect(result[:complex][:object]).wont_be_kind_of(Contours::StructuredString)
+      end
     end
 
     describe "blending keys" do


### PR DESCRIPTION
Using to_hash or ** will recursively convert StructuredString values into regular String objects.