### PR TITLE
Add shared release workflow from reissue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release gem to RubyGems.org
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main
+    with:
+      git_user_email: 'gems@sofwarellc.com'
+      git_user_name: 'SOFware'
+      ruby_version: '3.4'

--- a/README.md
+++ b/README.md
@@ -62,16 +62,7 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
-This project is managed with [Reissue](https://github.com/SOFware/reissue).
-
-Add git trailers for changelog entries according to the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
-
-To release a new version, make your changes and be sure to update the CHANGELOG.md.
-
-To release a new version:
-
-1. `bundle exec rake build:checksum`
-2. `bundle exec rake release`
+This project is managed with [Reissue](https://github.com/SOFware/reissue). Releases are automated via the [shared release workflow](https://github.com/SOFware/reissue/blob/main/.github/workflows/SHARED_WORKFLOW_README.md). Trigger a release by running the "Release gem to RubyGems.org" workflow from the Actions tab.
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,5 @@ Reissue::Task.create do |t|
   t.version_file = "lib/contours/version.rb"
   t.version_limit = 3
   t.fragment = :git
+  t.push_finalize = :branch
 end


### PR DESCRIPTION
## Summary
- Adds shared release workflow from reissue for trusted publishing to RubyGems.org

## Business Justification
Standardizes gem release process across SOFware repos using the shared reissue workflow, enabling automated trusted publishing to RubyGems.org via workflow_dispatch.

## Technical Details
Adds `.github/workflows/release.yml` that calls `SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main`