### PR TITLE
Bump required_ruby_version to >= 3.3

### DIFF
--- a/contours.gemspec
+++ b/contours.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
     which can be customized by merging in other configuration objects.
   DESC
   spec.homepage = "https://github.com/SOFware/contours"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
## Summary
- Bump `required_ruby_version` in the gemspec to `>= 3.3.0`

## Business Justification
Ruby 3.2 reached end-of-life on 2025-03-31, and earlier 3.x lines have been EOL longer. Advertising support for those versions in the gemspec misleads downstream consumers and lets them install us on Ruby they shouldn't be running. 3.3 is the oldest non-EOL line, so this aligns the gemspec floor with what we actually test against in CI.

## Technical Details
Metadata-only change. CI already runs against 3.3+, so no code changes are required.
